### PR TITLE
Fix nan values

### DIFF
--- a/src/components/inputs/NumberInput.vue
+++ b/src/components/inputs/NumberInput.vue
@@ -7,7 +7,7 @@
 		<input type="number" :id="id" class="form-control" :class="validationClass" v-bind="$attrs" :min="props.min"
 			   :max="props.max" :step="props.step" :disabled="props.disabled" :required="props.required"
 			   :data-unit="unit" v-preset="(props.preset != null) ? props.preset * props.factor : null"
-			   :value="props.modelValue * props.factor" @change="onChange" @input="onInput">
+			   :value="(props.modelValue != null) ? props.modelValue * props.factor : null" @change="onChange" @input="onInput">
 		<span v-if="!!props.unit && !props.hideUnit" class="input-group-text">
 			<slot name="unit">
 				{{ props.unit }}
@@ -59,7 +59,7 @@ export interface NumberInputProps {
 	/**
 	 * Current value
 	 */
-	modelValue: number,
+	modelValue: number | null,
 
 	/**
 	 * Preset value (if applicable)
@@ -115,7 +115,7 @@ const id = `number-${++numInstances}`;
 // Validation
 const validationClass = computed<string | null>(() => {
 	if (!props.disabled && props.required) {
-		return (props.valid &&
+		return (props.valid && (props.modelValue != null) &&
 				!isNaN(props.modelValue) && isFinite(props.modelValue) &&
 				(props.min === undefined || props.modelValue * props.factor >= props.min) &&
 				(props.max === undefined || props.modelValue * props.factor <= props.max)) ? "is-valid" : "is-invalid";

--- a/src/components/inputs/TwoNumberInput.vue
+++ b/src/components/inputs/TwoNumberInput.vue
@@ -10,7 +10,7 @@
 		<input :id="id" class="form-control" :class="props.disabled ? '' : (isFinite(props.firstValue!) ? 'is-valid' : 'is-invalid')"
 			   type="number" :disabled="disabled" required :min="props.min"
 			   :max="(!props.disabled && props.isRange && setTwoNumbers) ? props.secondValue! : props.max" :step="props.step"
-			   :value="props.firstValue ?? NaN" v-preset="firstPreset" :data-unit="props.unit" :title="props.firstTitle"
+			   :value="props.firstValue ?? null" v-preset="firstPreset" :data-unit="props.unit" :title="props.firstTitle"
 			   @input="onFirstInput">
 		<template v-if="setTwoNumbers">
 			<span class="input-group-text">
@@ -18,7 +18,7 @@
 			</span>
 			<input class="form-control" :class="props.disabled ? '' : (isFinite(props.secondValue!) ? 'is-valid' : 'is-invalid')" type="number"
 				   required :disabled="disabled" :min="(!props.disabled && props.isRange) ? props.firstValue! : props.min" :max="props.max"
-				   :step="props.step" :value="props.secondValue ?? NaN" v-preset="secondPreset" :data-unit="props.unit"
+				   :step="props.step" :value="props.secondValue ?? null" v-preset="secondPreset" :data-unit="props.unit"
 				   :title="props.secondTitle" @input="onSecondInput">
 		</template>
 		<span v-if="props.unit" class="input-group-text">

--- a/src/components/sections/Drivers.vue
+++ b/src/components/sections/Drivers.vue
@@ -316,7 +316,7 @@ function getCurrent(driver: ConfigDriver) {
 		}
 	}
 
-	return NaN;
+	return null;
 }
 
 function setCurrent(driver: ConfigDriver, value: number) {

--- a/src/components/sections/Endstops.vue
+++ b/src/components/sections/Endstops.vue
@@ -196,11 +196,11 @@ function getEndstopTypeOptions(axis: StoreState<Axis>): Array<SelectOption> {
 	// SG support depends on the corresponding expansion/main board
 	if (!store.data.boards.some(board => !store.data.getBoardDefinition(board.canAddress)?.hasSmartDrivers)) {
 		options.push({
-			text: "Singe Motor Load Detection",
+			text: "Single Motor Load Detection",
 			value: EndstopType.motorStallAny
 		});
 		options.push({
-			text: "Multple Motor Load Detection",
+			text: "Multiple Motor Load Detection",
 			value: EndstopType.motorStallIndividual
 		});
 	}


### PR DESCRIPTION
An error "The specified value "NaN" cannot be parsed, or is out of range." appears in the console when unassigning a driver from an axis or unassigning a monitored sensor to a fan because NaN value is set to input components instead of null value.
\+ typo fix for the endstops select