### PR TITLE
Thermostatic fan fix and target position not reachable in homedelta.g

### DIFF
--- a/public/templates/config/fans.ejs
+++ b/public/templates/config/fans.ejs
@@ -11,7 +11,7 @@ M106 <%- params({
     C: fan.name ? fan.name : undefined,
     S: fan.requestedValue,
     L: fan.thermostatic.sensors.length ? undefined : fan.min,
-    X: fan.thermostatic.sensors.length ? undefined : fan.max,
+    X: (fan.thermostatic.sensors.length && fan.thermostatic.lowTemperature != fan.thermostatic.highTemperature) ? undefined : fan.max,
     B: fan.blip,
     H: fan.thermostatic.sensors.length ? fan.thermostatic.sensors : undefined,
     T: fan.thermostatic.sensors.length ? reduce([fan.thermostatic.lowTemperature, fan.thermostatic.highTemperature]) : undefined

--- a/public/templates/homedelta.ejs
+++ b/public/templates/homedelta.ejs
@@ -59,6 +59,9 @@ G1 <%- params({
     Z: highEndstops ? "{var.homedHeight}" : "{-var.homedHeight}",
     F: fastHomingSpeed * 60
 }) %> ; move all towers to the <%- highEndstops ? "high" : "low" %> end once more stopping at the endstops
+<%  if (highEndstops) { -%>
+G1 Z-5 F6000 ; go down a bit so we can move to the center (fixes "G1: target position not reachable from current position" issue)
+<%  } -%>
 G90 ; absolute positioning
 G1 X0 Y0 F<%- travelSpeed %> ; move X and Y to the centre
 


### PR DESCRIPTION
I did find a couple of small issues when setting up my custom delta printer recently. So here comes a couple of proposals to fix it :)

The first thing I noticed what that when running a fan in thermostatic mode it always run in 100%. Reading the M106 documentation I found examples on running a thermostatic trigger and a reduced fan speed at 70%
`M106 P1 T45 H1:2 X0.7`

The second thing I found was that my homing sequence randomly failed with `Error: in file macro line 13: G1: target position not reachable from current position`. This is because when homing against high side limit switches is finished, all axis is at their maximum allowed position and its then not possible to move to `X0 Y0`. I'm guessing it's a rounding error somewhere in the reprap firmware that causing this but moving the axis away from their limits fixes the issue.
